### PR TITLE
fix for rails 6.1

### DIFF
--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -37,13 +37,10 @@ module Panoramic
       identifier = "#{record.class} - #{record.id} - #{record.path.inspect}"
       handler = ActionView::Template.registered_template_handler(record.handler)
 
-      details = {
-        :format => Mime[record.format].to_sym,
-        :updated_at => record.updated_at,
-        :virtual_path => virtual_path(record.path, record.partial)
-      }
-
-      ActionView::Template.new(source, identifier, handler, details)
+      ActionView::Template.new(source, identifier, handler,
+                               :locals => [],
+                               :format => Mime[record.format].to_sym,
+                               :virtual_path => virtual_path(record.path, record.partial))
     end
 
     # Build path with eventual prefix


### PR DESCRIPTION
In rails 6.1 the gem does not work narrowed it down to lib/panoramic/resolver.rb 46

actionview (6.1.0) lib/action_view/template.rb initialize
`initalize(source, identifier, handler, locals:, format: nil, variant: nil, virtual_path: nil)`
the call to add is made like this

`ActionView::Template.new(source, identifier, handler, details)`

which does not include locals named argument

was not throwing an error in 6.0 because of default value provided
`initalize(source, identifier, handler, format: nil, variant: nil, locals: nil, virtual_path: nil, updated_at: nil)`

can be fixed for 6.1 like this

```
      ActionView::Template.new(source, identifier, handler,
                               :locals => [],
                               :format => Mime[record.format].to_sym,
                               :virtual_path => virtual_path(record.path, record.partial))
```
not sure of what is needed to make it compatible with all versions
